### PR TITLE
chore: test vite sass sourcemap pr

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "unplugin-fonts": "^1.1.1",
     "unplugin-vue-components": "^0.27.2",
     "unplugin-vue-router": "^0.10.0",
-    "vite": "^5.4.2",
+    "vite": "https://pkg.pr.new/vite@561b940",
     "vite-plugin-inspect": "^0.8.7",
     "vite-plugin-vuetify": "^2.0.4",
     "vue-router": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 20.16.1
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.1.2(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))
+        version: 5.1.2(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))
       '@vue/eslint-config-typescript':
         specifier: ^13.0.0
         version: 13.0.0(eslint-plugin-vue@9.27.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.5.4)
@@ -65,7 +65,7 @@ importers:
         version: 5.5.4
       unplugin-fonts:
         specifier: ^1.1.1
-        version: 1.1.1(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))
+        version: 1.1.1(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))
       unplugin-vue-components:
         specifier: ^0.27.2
         version: 0.27.4(@babel/parser@7.25.4)(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4))
@@ -73,14 +73,14 @@ importers:
         specifier: ^0.10.0
         version: 0.10.7(rollup@4.21.0)(vue-router@4.4.3(vue@3.4.38(typescript@5.5.4)))(vue@3.4.38(typescript@5.5.4))
       vite:
-        specifier: ^5.4.2
-        version: 5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)
+        specifier: https://pkg.pr.new/vite@561b940
+        version: https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)
       vite-plugin-inspect:
         specifier: ^0.8.7
-        version: 0.8.7(rollup@4.21.0)(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))
+        version: 0.8.7(rollup@4.21.0)(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))
       vite-plugin-vuetify:
         specifier: ^2.0.4
-        version: 2.0.4(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0)
+        version: 2.0.4(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0)
       vue-router:
         specifier: ^4.4.3
         version: 4.4.3(vue@3.4.38(typescript@5.5.4))
@@ -464,6 +464,7 @@ packages:
 
   '@vitejs/plugin-vue@5.1.2':
     resolution: {integrity: sha512-nY9IwH12qeiJqumTCLJLE7IiNx7HZ39cbHaysEUd+Myvbz9KAqd2yq+U01Kab1R/H1BmiyM2ShTYlNH32Fzo3A==}
+    version: 5.1.2
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0
@@ -1734,6 +1735,7 @@ packages:
 
   unplugin-fonts@1.1.1:
     resolution: {integrity: sha512-/Aw/rL9D2aslGGM0vi+2R2aG508RSwawLnnBuo+JDSqYc4cHJO1R1phllhN6GysEhBp/6a4B6+vSFPVapWyAAw==}
+    version: 1.1.1
     peerDependencies:
       '@nuxt/kit': ^3.0.0
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -1781,6 +1783,7 @@ packages:
 
   vite-plugin-inspect@0.8.7:
     resolution: {integrity: sha512-/XXou3MVc13A5O9/2Nd6xczjrUwt7ZyI9h8pTnUMkr5SshLcb0PJUOVq2V+XVkdeU4njsqAtmK87THZuO2coGA==}
+    version: 0.8.7
     engines: {node: '>=14'}
     peerDependencies:
       '@nuxt/kit': '*'
@@ -1791,14 +1794,16 @@ packages:
 
   vite-plugin-vuetify@2.0.4:
     resolution: {integrity: sha512-A4cliYUoP/u4AWSRVRvAPKgpgR987Pss7LpFa7s1GvOe8WjgDq92Rt3eVXrvgxGCWvZsPKziVqfHHdCMqeDhfw==}
+    version: 2.0.4
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: '>=5'
       vue: ^3.0.0
       vuetify: ^3.0.0
 
-  vite@5.4.2:
-    resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
+  vite@https://pkg.pr.new/vite@561b940:
+    resolution: {tarball: https://pkg.pr.new/vite@561b940}
+    version: 5.4.2
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -2203,9 +2208,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-vue@5.1.2(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.1.2(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))':
     dependencies:
-      vite: 5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)
+      vite: https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)
       vue: 3.4.38(typescript@5.5.4)
 
   '@volar/language-core@2.4.0':
@@ -3632,11 +3637,11 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-fonts@1.1.1(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)):
+  unplugin-fonts@1.1.1(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)):
     dependencies:
       fast-glob: 3.3.2
       unplugin: 1.12.2
-      vite: 5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)
+      vite: https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)
 
   unplugin-vue-components@0.27.4(@babel/parser@7.25.4)(rollup@4.21.0)(vue@3.4.38(typescript@5.5.4)):
     dependencies:
@@ -3696,7 +3701,7 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite-plugin-inspect@0.8.7(rollup@4.21.0)(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)):
+  vite-plugin-inspect@0.8.7(rollup@4.21.0)(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@4.21.0)
@@ -3707,23 +3712,23 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)
+      vite: https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vuetify@2.0.4(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0):
+  vite-plugin-vuetify@2.0.4(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0):
     dependencies:
       '@vuetify/loader-shared': 2.0.3(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.0.4)(vue@3.4.38(typescript@5.5.4)))
       debug: 4.3.6
       upath: 2.0.1
-      vite: 5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8)
+      vite: https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8)
       vue: 3.4.38(typescript@5.5.4)
       vuetify: 3.7.0(typescript@5.5.4)(vite-plugin-vuetify@2.0.4)(vue@3.4.38(typescript@5.5.4))
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8):
+  vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.41
@@ -3775,7 +3780,7 @@ snapshots:
       vue: 3.4.38(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
-      vite-plugin-vuetify: 2.0.4(vite@5.4.2(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0)
+      vite-plugin-vuetify: 2.0.4(vite@https://pkg.pr.new/vite@561b940(@types/node@20.16.1)(sass-embedded@1.77.8))(vue@3.4.38(typescript@5.5.4))(vuetify@3.7.0)
 
   webpack-sources@3.2.3: {}
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,13 +10,14 @@ import { fileURLToPath, URL } from 'node:url'
 // https://vitejs.dev/config/
 export default defineConfig({
   css: {
-    // add this to check missing source sass files: disabled by default
-    // devSourcemap: true,
-    preprocessorOptions: {
-      sass: {
-        api: 'modern-compiler',
-      },
-    },
+    // with https://github.com/vitejs/vite/pull/17938 this works
+    devSourcemap: true,
+    // with https://github.com/vitejs/vite/pull/17938 we need to remove this entry
+    // preprocessorOptions: {
+    //   sass: {
+    //     api: 'modern-compiler',
+    //   },
+    // },
     //preprocessorMaxWorkers: true,
   },
   plugins: [


### PR DESCRIPTION
Using Vite from this PR https://github.com/vitejs/vite/pull/17938 we need to exclude css modern sass compiler, and `css.devSourcemap` working: check `vite.config.mts`